### PR TITLE
Refactor Character Handler + Face Overwrite Function

### DIFF
--- a/CharFileLibrary/Character_Making_File_Tool/CharacterHandlerReboot.cs
+++ b/CharFileLibrary/Character_Making_File_Tool/CharacterHandlerReboot.cs
@@ -409,7 +409,8 @@ namespace Character_Making_File_Tool
 
         public class xxpGeneralReboot
         {
-            public int xxpVersion; 
+            public int xxpVersion;
+            public int fileSize;
 
             public BaseDOC baseDOC;
             public byte skinVariant; //0 or above 3 for default, 1 for human, 2 for dewman, 3 for cast. This decides the color map used for the skin. 
@@ -474,9 +475,52 @@ namespace Character_Making_File_Tool
             {
             }
 
-            public xxpGeneralReboot(XXPV2 tempXXP)
+            protected void SetDefaultExpressions()
             {
-                xxpVersion = 10;
+                if (baseDOC.gender == 0)
+                {
+                    faceNatural = defaultMaleExpressions[0];
+                    faceSmile = defaultMaleExpressions[1];
+                    faceAngry = defaultMaleExpressions[2];
+                    faceSad = defaultMaleExpressions[3];
+
+                    faceSus = defaultMaleExpressions[4];
+                    faceEyesClosed = defaultMaleExpressions[5];
+                    faceSmile2 = defaultMaleExpressions[6];
+                    faceWink = defaultMaleExpressions[7];
+
+                    faceUnused1 = defaultMaleExpressions[8];
+                    faceUnused2 = defaultMaleExpressions[9];
+                }
+                else
+                {
+                    faceNatural = defaultFemaleExpressions[0];
+                    faceSmile = defaultFemaleExpressions[1];
+                    faceAngry = defaultFemaleExpressions[2];
+                    faceSad = defaultFemaleExpressions[3];
+
+                    faceSus = defaultFemaleExpressions[4];
+                    faceEyesClosed = defaultFemaleExpressions[5];
+                    faceSmile2 = defaultFemaleExpressions[6];
+                    faceWink = defaultFemaleExpressions[7];
+
+                    faceUnused1 = defaultFemaleExpressions[8];
+                    faceUnused2 = defaultFemaleExpressions[9];
+                }
+            }
+
+            public virtual byte[] GetBytes()
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        public class xxpGeneralRebootV2 : xxpGeneralReboot
+        {
+            public xxpGeneralRebootV2(XXPV2 tempXXP)
+            {
+                xxpVersion = 2;
+                fileSize = 0x15C;
 
                 baseDOC = tempXXP.baseDOC;
                 skinVariant = 0;
@@ -493,10 +537,11 @@ namespace Character_Making_File_Tool
                 //Eye parts 
                 byte[] eyes = BitConverter.GetBytes(baseSLCT.eyePart);
                 baseSLCT.eyePart = eyes[0];
-                if(baseDOC.race == 3)
+                if (baseDOC.race == 3)
                 {
                     leftEyePart = eyes[1];
-                } else
+                }
+                else
                 {
                     leftEyePart = eyes[0];
                 }
@@ -507,9 +552,31 @@ namespace Character_Making_File_Tool
                 paintPriority = PaintPriority.GetDefault();
             }
 
-            public xxpGeneralReboot(XXPV5 tempXXP)
+            public XXPV2 GetXXP()
             {
-                xxpVersion = 10;
+                XXPV2 xxpv2 = new XXPV2();
+
+                xxpv2.baseDOC = baseDOC;
+                xxpv2.baseFIGR = baseFIGR;
+                xxpv2.baseFIGR.ToOld();
+                xxpv2.baseCOLR = ColorConversion.COL2ToCOLR(ngsCOL2, baseDOC.race);
+                xxpv2.baseSLCT = baseSLCT;
+
+                return xxpv2;
+            }
+
+            public override byte[] GetBytes()
+            {
+                return Reloaded.Memory.Struct.GetBytes(GetXXP());
+            }
+        }
+
+        public class xxpGeneralRebootV5 : xxpGeneralReboot
+        {
+            public xxpGeneralRebootV5(XXPV5 tempXXP)
+            {
+                xxpVersion = 5;
+                fileSize = 0x170;
 
                 baseDOC = tempXXP.baseDOC;
                 skinVariant = 0;
@@ -544,9 +611,33 @@ namespace Character_Making_File_Tool
                 paintPriority = PaintPriority.GetDefault();
             }
 
-            public xxpGeneralReboot(XXPV6 tempXXP)
+            public XXPV5 GetXXP()
             {
-                xxpVersion = 10;
+                XXPV5 xxpv5 = new XXPV5();
+
+                xxpv5.baseDOC = baseDOC;
+                xxpv5.baseFIGR = baseFIGR;
+                xxpv5.baseFIGR.ToOld();
+                xxpv5.baseCOLR = ColorConversion.COL2ToCOLR(ngsCOL2, baseDOC.race);
+                xxpv5.baseSLCT = baseSLCT;
+                xxpv5.baseSLCT2 = baseSLCT2;
+                xxpv5.oldPosSliders = accessorySlidersReboot.GetOldAccessoryPositionSliders();
+
+                return xxpv5;
+            }
+
+            public override byte[] GetBytes()
+            {
+                return Reloaded.Memory.Struct.GetBytes(GetXXP());
+            }
+        }
+
+        public class xxpGeneralRebootV6 : xxpGeneralReboot
+        {
+            public xxpGeneralRebootV6(XXPV6 tempXXP)
+            {
+                xxpVersion = 6;
+                fileSize = 0x2DC;
 
                 baseDOC = tempXXP.baseDOC;
                 skinVariant = 0;
@@ -585,9 +676,46 @@ namespace Character_Making_File_Tool
                 paintPriority = PaintPriority.GetDefault();
             }
 
-            public xxpGeneralReboot(XXPV7 tempXXP)
+            public XXPV6 GetXXP()
             {
-                xxpVersion = 10;
+                XXPV6 xxpv6 = new XXPV6();
+
+                xxpv6.baseDOC = baseDOC;
+                xxpv6.baseFIGR = baseFIGR;
+                xxpv6.baseFIGR.ToOld();
+
+                xxpv6.baseFIGR2 = new BaseFIGR2();
+                xxpv6.baseFIGR2.neckVerts = neckVerts;
+                xxpv6.baseFIGR2.waistVerts = waistVerts;
+                xxpv6.baseFIGR2.neck2Verts = neckVerts;
+                xxpv6.baseFIGR2.waist2Verts = waistVerts;
+                xxpv6.baseFIGR2.arm2Verts = baseFIGR.armVerts;
+                xxpv6.baseFIGR2.body2Verts = baseFIGR.bodyVerts;
+                xxpv6.baseFIGR2.bust2Verts = baseFIGR.bustVerts;
+                xxpv6.baseFIGR2.leg2Verts = baseFIGR.legVerts;
+                xxpv6.baseFIGR2.ToOld();
+
+                xxpv6.baseCOLR = ColorConversion.COL2ToCOLR(ngsCOL2, baseDOC.race);
+                xxpv6.baseSLCT = baseSLCT;
+                xxpv6.baseSLCT2 = baseSLCT2;
+                xxpv6.oldAccessorySliders = accessorySlidersReboot.GetOldAccessorySliders();
+                xxpv6.paintPriority = paintPriority;
+
+                return xxpv6;
+            }
+
+            public override byte[] GetBytes()
+            {
+                return Reloaded.Memory.Struct.GetBytes(GetXXP());
+            }
+        }
+
+        public class xxpGeneralRebootV7 : xxpGeneralReboot
+        {
+            public xxpGeneralRebootV7(XXPV7 tempXXP)
+            {
+                xxpVersion = 7;
+                fileSize = 0; // TODO: Get filesize for V7
 
                 baseDOC = tempXXP.baseDOC;
                 skinVariant = 0;
@@ -626,9 +754,46 @@ namespace Character_Making_File_Tool
                 paintPriority = PaintPriority.GetDefault();
             }
 
-            public xxpGeneralReboot(XXPV9 tempXXP)
+            public XXPV7 GetXXP() // TODO This is copied from V6
+            {
+                XXPV7 xxpv7 = new XXPV7();
+
+                xxpv7.baseDOC = baseDOC;
+                xxpv7.baseFIGR = baseFIGR;
+                xxpv7.baseFIGR.ToOld();
+
+                xxpv7.baseFIGR2 = new BaseFIGR2();
+                xxpv7.baseFIGR2.neckVerts = neckVerts;
+                xxpv7.baseFIGR2.waistVerts = waistVerts;
+                xxpv7.baseFIGR2.neck2Verts = neckVerts;
+                xxpv7.baseFIGR2.waist2Verts = waistVerts;
+                xxpv7.baseFIGR2.arm2Verts = baseFIGR.armVerts;
+                xxpv7.baseFIGR2.body2Verts = baseFIGR.bodyVerts;
+                xxpv7.baseFIGR2.bust2Verts = baseFIGR.bustVerts;
+                xxpv7.baseFIGR2.leg2Verts = baseFIGR.legVerts;
+                xxpv7.baseFIGR2.ToOld();
+
+                xxpv7.baseCOLR = ColorConversion.COL2ToCOLR(ngsCOL2, baseDOC.race);
+                xxpv7.baseSLCT = baseSLCT;
+                xxpv7.baseSLCT2 = baseSLCT2;
+                xxpv7.accessorySliders = accessorySlidersReboot.GetClassicAccessorySliders();
+                xxpv7.paintPriority = paintPriority;
+
+                return xxpv7;
+            }
+
+            public override byte[] GetBytes()
+            {
+                return Reloaded.Memory.Struct.GetBytes(GetXXP());
+            }
+        }
+
+        public class xxpGeneralRebootV9 : xxpGeneralReboot
+        {
+            public xxpGeneralRebootV9(XXPV9 tempXXP)
             {
                 xxpVersion = 10;
+                fileSize = 0x2F0;
 
                 baseDOC = tempXXP.baseDOC;
                 skinVariant = tempXXP.skinVariant;
@@ -665,9 +830,51 @@ namespace Character_Making_File_Tool
                 paintPriority = PaintPriority.GetDefault();
             }
 
-            public xxpGeneralReboot(XXPV10 tempXXP)
+            public XXPV9 GetXXP()
+            {
+                XXPV9 xxpv9 = new XXPV9();
+
+                xxpv9.baseDOC = baseDOC;
+                xxpv9.skinVariant = 3; //Hack to deal with limitations of backwards conversion
+                xxpv9.eyebrowDensity = eyebrowDensity;
+                xxpv9.cmlVariant = cmlVariant;
+
+                xxpv9.baseFIGR = baseFIGR;
+                xxpv9.baseFIGR.ToOld();
+
+                xxpv9.baseFIGR2 = new BaseFIGR2();
+                xxpv9.baseFIGR2.neckVerts = neckVerts;
+                xxpv9.baseFIGR2.waistVerts = waistVerts;
+                xxpv9.baseFIGR2.neck2Verts = neckVerts;
+                xxpv9.baseFIGR2.waist2Verts = waistVerts;
+                xxpv9.baseFIGR2.arm2Verts = baseFIGR.armVerts;
+                xxpv9.baseFIGR2.body2Verts = baseFIGR.bodyVerts;
+                xxpv9.baseFIGR2.bust2Verts = baseFIGR.bustVerts;
+                xxpv9.baseFIGR2.leg2Verts = baseFIGR.legVerts;
+                xxpv9.baseFIGR2.ToOld();
+
+                xxpv9.baseCOLR = ColorConversion.COL2ToCOLR(ngsCOL2, baseDOC.race);
+                xxpv9.baseSLCT = baseSLCT;
+                xxpv9.baseSLCT2 = baseSLCT2;
+                xxpv9.leftEyePart = leftEyePart;
+                xxpv9.accessorySliders = accessorySlidersReboot.GetClassicAccessorySliders();
+                xxpv9.paintPriority = paintPriority;
+
+                return xxpv9;
+            }
+
+            public override byte[] GetBytes()
+            {
+                return Reloaded.Memory.Struct.GetBytes(GetXXP());
+            }
+        }
+
+        public class xxpGeneralRebootV10 : xxpGeneralReboot
+        {
+            public xxpGeneralRebootV10(XXPV10 tempXXP)
             {
                 xxpVersion = 10;
+                fileSize = 0x3AC;
 
                 baseDOC = tempXXP.baseDOC;
                 skinVariant = tempXXP.skinVariant;
@@ -719,9 +926,61 @@ namespace Character_Making_File_Tool
                 accessoryMiscData = tempXXP.accessoryMiscData;
             }
 
-            public xxpGeneralReboot(XXPV11 tempXXP)
+            public XXPV10 GetXXP()
+            {
+                XXPV10 tempXXP = new XXPV10();
+
+                tempXXP.baseDOC = baseDOC;
+                tempXXP.skinVariant = skinVariant;
+                tempXXP.eyebrowDensity = eyebrowDensity;
+                tempXXP.cmlVariant = cmlVariant;
+                tempXXP.baseFIGR = baseFIGR;
+                tempXXP.neckVerts = neckVerts;
+                tempXXP.waistVerts = waistVerts;
+                tempXXP.hands = hands;
+                tempXXP.horns = horns;
+                tempXXP.eyeSize = eyeSize;
+                tempXXP.eyeHorizontalPosition = eyeHorizontalPosition;
+                tempXXP.neckAngle = neckAngle;
+                tempXXP.ngsCOL2 = ngsCOL2;
+                tempXXP.baseSLCT = baseSLCT;
+                tempXXP.baseSLCT2 = baseSLCT2;
+                tempXXP.leftEyePart = leftEyePart;
+                tempXXP.baseSLCTNGS = baseSLCTNGS;
+                tempXXP.accessorySlidersReboot = accessorySlidersReboot;
+                tempXXP.faceNatural = faceNatural.expStruct;
+                tempXXP.faceSmile = faceSmile.expStruct;
+                tempXXP.faceAngry = faceAngry.expStruct;
+                tempXXP.faceSad = faceSad.expStruct;
+                tempXXP.faceSus = faceSus.expStruct;
+                tempXXP.faceEyesClosed = faceEyesClosed.expStruct;
+                tempXXP.faceSmile2 = faceSmile2.expStruct;
+                tempXXP.faceWink = faceWink.expStruct;
+                tempXXP.faceUnused1 = faceUnused1.expStruct;
+                tempXXP.faceUnused2 = faceUnused2.expStruct;
+                tempXXP.paintPriority = paintPriority;
+                tempXXP.ngsSLID = ngsSLID;
+                tempXXP.ngsMTON = ngsMTON;
+                tempXXP.int_350 = int_350;
+                tempXXP.int_354 = int_354;
+                tempXXP.ngsVISI = ngsVISI;
+                tempXXP.accessoryMiscData = accessoryMiscData;
+
+                return tempXXP;
+            }
+
+            public override byte[] GetBytes()
+            {
+                return Reloaded.Memory.Struct.GetBytes(GetXXP());
+            }
+        }
+
+        public class xxpGeneralRebootV11 : xxpGeneralReboot
+        {
+            public xxpGeneralRebootV11(XXPV11 tempXXP)
             {
                 xxpVersion = 11;
+                fileSize = 0x3C0;
 
                 baseDOC = tempXXP.baseDOC;
                 skinVariant = tempXXP.skinVariant;
@@ -773,9 +1032,61 @@ namespace Character_Making_File_Tool
                 accessoryMiscData = tempXXP.accessoryMiscData;
             }
 
-            public xxpGeneralReboot(XXPV12 tempXXP)
+            public XXPV11 GetXXP()
+            {
+                XXPV11 tempXXP = new XXPV11();
+
+                tempXXP.baseDOC = baseDOC;
+                tempXXP.skinVariant = skinVariant;
+                tempXXP.eyebrowDensity = eyebrowDensity;
+                tempXXP.cmlVariant = cmlVariant;
+                tempXXP.baseFIGR = baseFIGR;
+                tempXXP.neckVerts = neckVerts;
+                tempXXP.waistVerts = waistVerts;
+                tempXXP.hands = hands;
+                tempXXP.horns = horns;
+                tempXXP.eyeSize = eyeSize;
+                tempXXP.eyeHorizontalPosition = eyeHorizontalPosition;
+                tempXXP.neckAngle = neckAngle;
+                tempXXP.ngsCOL2 = ngsCOL2;
+                tempXXP.baseSLCT = baseSLCT;
+                tempXXP.baseSLCT2 = baseSLCT2;
+                tempXXP.leftEyePart = leftEyePart;
+                tempXXP.baseSLCTNGS = baseSLCTNGS;
+                tempXXP.accessorySlidersReboot = accessorySlidersReboot;
+                tempXXP.faceNatural = faceNatural;
+                tempXXP.faceSmile = faceSmile;
+                tempXXP.faceAngry = faceAngry;
+                tempXXP.faceSad = faceSad;
+                tempXXP.faceSus = faceSus;
+                tempXXP.faceEyesClosed = faceEyesClosed;
+                tempXXP.faceSmile2 = faceSmile2;
+                tempXXP.faceWink = faceWink;
+                tempXXP.faceUnused1 = faceUnused1;
+                tempXXP.faceUnused2 = faceUnused2;
+                tempXXP.paintPriority = paintPriority;
+                tempXXP.ngsSLID = ngsSLID;
+                tempXXP.ngsMTON = ngsMTON;
+                tempXXP.int_350 = int_350;
+                tempXXP.int_354 = int_354;
+                tempXXP.ngsVISI = ngsVISI;
+                tempXXP.accessoryMiscData = accessoryMiscData;
+
+                return tempXXP;
+            }
+
+            public override byte[] GetBytes()
+            {
+                return Reloaded.Memory.Struct.GetBytes(GetXXP());
+            }
+        }
+
+        public class xxpGeneralRebootV12 : xxpGeneralReboot
+        {
+            public xxpGeneralRebootV12(XXPV12 tempXXP)
             {
                 xxpVersion = 12;
+                fileSize = 0x438;
 
                 baseDOC = tempXXP.baseDOC;
                 skinVariant = tempXXP.skinVariant;
@@ -829,182 +1140,7 @@ namespace Character_Making_File_Tool
                 accessoryMiscData = tempXXP.accessoryMiscData;
             }
 
-            public XXPV2 GetXXPV2()
-            {
-                XXPV2 xxpv2 = new XXPV2();
-
-                xxpv2.baseDOC = baseDOC;
-                xxpv2.baseFIGR = baseFIGR;
-                xxpv2.baseFIGR.ToOld();
-                xxpv2.baseCOLR = ColorConversion.COL2ToCOLR(ngsCOL2, baseDOC.race);
-                xxpv2.baseSLCT = baseSLCT;
-
-                return xxpv2;
-            }
-
-            public XXPV5 GetXXPV5()
-            {
-                XXPV5 xxpv5 = new XXPV5();
-
-                xxpv5.baseDOC = baseDOC;
-                xxpv5.baseFIGR = baseFIGR;
-                xxpv5.baseFIGR.ToOld();
-                xxpv5.baseCOLR = ColorConversion.COL2ToCOLR(ngsCOL2, baseDOC.race);
-                xxpv5.baseSLCT = baseSLCT;
-                xxpv5.baseSLCT2 = baseSLCT2;
-                xxpv5.oldPosSliders = accessorySlidersReboot.GetOldAccessoryPositionSliders();
-
-                return xxpv5;
-            }
-
-            public XXPV6 GetXXPV6()
-            {
-                XXPV6 xxpv6 = new XXPV6();
-
-                xxpv6.baseDOC = baseDOC;
-                xxpv6.baseFIGR = baseFIGR;
-                xxpv6.baseFIGR.ToOld();
-
-                xxpv6.baseFIGR2 = new BaseFIGR2();
-                xxpv6.baseFIGR2.neckVerts = neckVerts;
-                xxpv6.baseFIGR2.waistVerts = waistVerts;
-                xxpv6.baseFIGR2.neck2Verts = neckVerts;
-                xxpv6.baseFIGR2.waist2Verts = waistVerts;
-                xxpv6.baseFIGR2.arm2Verts = baseFIGR.armVerts;
-                xxpv6.baseFIGR2.body2Verts = baseFIGR.bodyVerts;
-                xxpv6.baseFIGR2.bust2Verts = baseFIGR.bustVerts;
-                xxpv6.baseFIGR2.leg2Verts = baseFIGR.legVerts;
-                xxpv6.baseFIGR2.ToOld();
-
-                xxpv6.baseCOLR = ColorConversion.COL2ToCOLR(ngsCOL2, baseDOC.race);
-                xxpv6.baseSLCT = baseSLCT; 
-                xxpv6.baseSLCT2 = baseSLCT2;
-                xxpv6.oldAccessorySliders = accessorySlidersReboot.GetOldAccessorySliders();
-                xxpv6.paintPriority = paintPriority;
-
-                return xxpv6;
-            }
-
-            public XXPV9 GetXXPV9()
-            {
-                XXPV9 xxpv9 = new XXPV9();
-
-                xxpv9.baseDOC = baseDOC;
-                xxpv9.skinVariant = 3; //Hack to deal with limitations of backwards conversion
-                xxpv9.eyebrowDensity = eyebrowDensity;
-                xxpv9.cmlVariant = cmlVariant;
-                
-                xxpv9.baseFIGR = baseFIGR;
-                xxpv9.baseFIGR.ToOld();
-
-                xxpv9.baseFIGR2 = new BaseFIGR2();
-                xxpv9.baseFIGR2.neckVerts = neckVerts;
-                xxpv9.baseFIGR2.waistVerts = waistVerts;
-                xxpv9.baseFIGR2.neck2Verts = neckVerts;
-                xxpv9.baseFIGR2.waist2Verts = waistVerts;
-                xxpv9.baseFIGR2.arm2Verts = baseFIGR.armVerts;
-                xxpv9.baseFIGR2.body2Verts = baseFIGR.bodyVerts;
-                xxpv9.baseFIGR2.bust2Verts = baseFIGR.bustVerts;
-                xxpv9.baseFIGR2.leg2Verts = baseFIGR.legVerts;
-                xxpv9.baseFIGR2.ToOld();
-
-                xxpv9.baseCOLR = ColorConversion.COL2ToCOLR(ngsCOL2, baseDOC.race);
-                xxpv9.baseSLCT = baseSLCT;
-                xxpv9.baseSLCT2 = baseSLCT2;
-                xxpv9.leftEyePart = leftEyePart;
-                xxpv9.accessorySliders = accessorySlidersReboot.GetClassicAccessorySliders();
-                xxpv9.paintPriority = paintPriority;
-
-                return xxpv9;
-            }
-
-            public XXPV10 GetXXPV10()
-            {
-                XXPV10 tempXXP = new XXPV10();
-
-                tempXXP.baseDOC = baseDOC;
-                tempXXP.skinVariant = skinVariant;
-                tempXXP.eyebrowDensity = eyebrowDensity;
-                tempXXP.cmlVariant = cmlVariant;
-                tempXXP.baseFIGR = baseFIGR;
-                tempXXP.neckVerts = neckVerts;
-                tempXXP.waistVerts = waistVerts;
-                tempXXP.hands = hands;
-                tempXXP.horns = horns;
-                tempXXP.eyeSize = eyeSize;
-                tempXXP.eyeHorizontalPosition = eyeHorizontalPosition;
-                tempXXP.neckAngle = neckAngle;
-                tempXXP.ngsCOL2 = ngsCOL2;
-                tempXXP.baseSLCT = baseSLCT;
-                tempXXP.baseSLCT2 = baseSLCT2;
-                tempXXP.leftEyePart = leftEyePart;
-                tempXXP.baseSLCTNGS = baseSLCTNGS;
-                tempXXP.accessorySlidersReboot = accessorySlidersReboot;
-                tempXXP.faceNatural = faceNatural.expStruct;
-                tempXXP.faceSmile = faceSmile.expStruct;
-                tempXXP.faceAngry = faceAngry.expStruct;
-                tempXXP.faceSad = faceSad.expStruct;
-                tempXXP.faceSus = faceSus.expStruct;
-                tempXXP.faceEyesClosed = faceEyesClosed.expStruct;
-                tempXXP.faceSmile2 = faceSmile2.expStruct;
-                tempXXP.faceWink = faceWink.expStruct;
-                tempXXP.faceUnused1 = faceUnused1.expStruct;
-                tempXXP.faceUnused2 = faceUnused2.expStruct;
-                tempXXP.paintPriority = paintPriority;
-                tempXXP.ngsSLID = ngsSLID;
-                tempXXP.ngsMTON = ngsMTON;
-                tempXXP.int_350 = int_350;
-                tempXXP.int_354 = int_354;
-                tempXXP.ngsVISI = ngsVISI;
-                tempXXP.accessoryMiscData = accessoryMiscData;
-
-                return tempXXP;
-            }
-
-            public XXPV11 GetXXPV11()
-            {
-                XXPV11 tempXXP = new XXPV11();
-
-                tempXXP.baseDOC = baseDOC;
-                tempXXP.skinVariant = skinVariant;
-                tempXXP.eyebrowDensity = eyebrowDensity;
-                tempXXP.cmlVariant = cmlVariant;
-                tempXXP.baseFIGR = baseFIGR;
-                tempXXP.neckVerts = neckVerts;
-                tempXXP.waistVerts = waistVerts;
-                tempXXP.hands = hands;
-                tempXXP.horns = horns;
-                tempXXP.eyeSize = eyeSize;
-                tempXXP.eyeHorizontalPosition = eyeHorizontalPosition;
-                tempXXP.neckAngle = neckAngle;
-                tempXXP.ngsCOL2 = ngsCOL2;
-                tempXXP.baseSLCT = baseSLCT;
-                tempXXP.baseSLCT2 = baseSLCT2;
-                tempXXP.leftEyePart = leftEyePart;
-                tempXXP.baseSLCTNGS = baseSLCTNGS;
-                tempXXP.accessorySlidersReboot = accessorySlidersReboot;
-                tempXXP.faceNatural = faceNatural;
-                tempXXP.faceSmile = faceSmile;
-                tempXXP.faceAngry = faceAngry;
-                tempXXP.faceSad = faceSad;
-                tempXXP.faceSus = faceSus;
-                tempXXP.faceEyesClosed = faceEyesClosed;
-                tempXXP.faceSmile2 = faceSmile2;
-                tempXXP.faceWink = faceWink;
-                tempXXP.faceUnused1 = faceUnused1;
-                tempXXP.faceUnused2 = faceUnused2;
-                tempXXP.paintPriority = paintPriority;
-                tempXXP.ngsSLID = ngsSLID;
-                tempXXP.ngsMTON = ngsMTON;
-                tempXXP.int_350 = int_350;
-                tempXXP.int_354 = int_354;
-                tempXXP.ngsVISI = ngsVISI;
-                tempXXP.accessoryMiscData = accessoryMiscData;
-
-                return tempXXP;
-            }
-
-            public XXPV12 GetXXPV12()
+            public XXPV12 GetXXP()
             {
                 XXPV12 tempXXP = new XXPV12();
 
@@ -1048,60 +1184,10 @@ namespace Character_Making_File_Tool
                 return tempXXP;
             }
 
-            private void SetDefaultExpressions()
+            public override byte[] GetBytes()
             {
-                if (baseDOC.gender == 0)
-                {
-                    faceNatural = defaultMaleExpressions[0];
-                    faceSmile = defaultMaleExpressions[1];
-                    faceAngry = defaultMaleExpressions[2];
-                    faceSad = defaultMaleExpressions[3];
-
-                    faceSus = defaultMaleExpressions[4];
-                    faceEyesClosed = defaultMaleExpressions[5];
-                    faceSmile2 = defaultMaleExpressions[6];
-                    faceWink = defaultMaleExpressions[7];
-
-                    faceUnused1 = defaultMaleExpressions[8];
-                    faceUnused2 = defaultMaleExpressions[9];
-                }
-                else
-                {
-                    faceNatural = defaultFemaleExpressions[0];
-                    faceSmile = defaultFemaleExpressions[1];
-                    faceAngry = defaultFemaleExpressions[2];
-                    faceSad = defaultFemaleExpressions[3];
-
-                    faceSus = defaultFemaleExpressions[4];
-                    faceEyesClosed = defaultFemaleExpressions[5];
-                    faceSmile2 = defaultFemaleExpressions[6];
-                    faceWink = defaultFemaleExpressions[7];
-
-                    faceUnused1 = defaultFemaleExpressions[8];
-                    faceUnused2 = defaultFemaleExpressions[9];
-                }
-            }
-
-            public byte[] GetBytes()
-            {
-                switch(xxpVersion)
-                {
-                    case 2:
-                        return Reloaded.Memory.Struct.GetBytes(GetXXPV2());
-                    case 5:
-                        return Reloaded.Memory.Struct.GetBytes(GetXXPV5());
-                    case 6:
-                        return Reloaded.Memory.Struct.GetBytes(GetXXPV6());
-                    case 9:
-                        return Reloaded.Memory.Struct.GetBytes(GetXXPV9());
-                    case 10:
-                        return Reloaded.Memory.Struct.GetBytes(GetXXPV10());
-                    case 11:
-                        return Reloaded.Memory.Struct.GetBytes(GetXXPV11());
-                }
-                throw new NotImplementedException();
+                return Reloaded.Memory.Struct.GetBytes(GetXXP());
             }
         }
-
     }
 }

--- a/CharFileLibrary/Character_Making_File_Tool/CharacterHandlerReboot.cs
+++ b/CharFileLibrary/Character_Making_File_Tool/CharacterHandlerReboot.cs
@@ -509,6 +509,37 @@ namespace Character_Making_File_Tool
                 }
             }
 
+            public AltFaceFIGR GetFaceFIGR()
+            {
+                AltFaceFIGR faceFIGR = new AltFaceFIGR();
+
+                faceFIGR.headVerts = baseFIGR.headVerts;
+                faceFIGR.faceShapeVerts = baseFIGR.faceShapeVerts;
+                faceFIGR.eyeShapeVerts = baseFIGR.eyeShapeVerts;
+                faceFIGR.noseHeightVerts = baseFIGR.noseHeightVerts;
+                faceFIGR.noseShapeVerts = baseFIGR.noseShapeVerts;
+                faceFIGR.mouthVerts = baseFIGR.mouthVerts;
+                faceFIGR.ear_hornVerts = baseFIGR.ear_hornVerts;
+                faceFIGR.neckVerts = neckVerts;
+                faceFIGR.horns = horns;
+                faceFIGR.unkFaceVerts = new Vec3Int();
+
+                return faceFIGR;
+            }
+
+            public void WriteFaceFIGR(AltFaceFIGR faceFIGR)
+            {
+                baseFIGR.headVerts = faceFIGR.headVerts;
+                baseFIGR.faceShapeVerts = faceFIGR.faceShapeVerts;
+                baseFIGR.eyeShapeVerts = faceFIGR.eyeShapeVerts;
+                baseFIGR.noseHeightVerts = faceFIGR.noseHeightVerts;
+                baseFIGR.noseShapeVerts = faceFIGR.noseShapeVerts;
+                baseFIGR.mouthVerts = faceFIGR.mouthVerts;
+                baseFIGR.ear_hornVerts = faceFIGR.ear_hornVerts;
+                neckVerts = faceFIGR.neckVerts;
+                horns = faceFIGR.horns;
+            }
+
             public virtual byte[] GetBytes()
             {
                 throw new NotImplementedException();
@@ -1182,6 +1213,16 @@ namespace Character_Making_File_Tool
                 tempXXP.accessoryMiscData = accessoryMiscData;
 
                 return tempXXP;
+            }
+
+            public AltFaceFIGR GetAltFaceFIGR()
+            {
+                return altFace;
+            }
+
+            public void WriteAltFaceFIGR(AltFaceFIGR altFaceFIGR)
+            {
+                altFace = altFaceFIGR;
             }
 
             public override byte[] GetBytes()

--- a/CharFileLibrary/Character_Making_File_Tool/Constants/CharacterConstants.cs
+++ b/CharFileLibrary/Character_Making_File_Tool/Constants/CharacterConstants.cs
@@ -38,12 +38,6 @@ namespace Character_Making_File_Tool
             { 0, 0x2F0}  //v9
         };
 
-        public static int v2Size = 0x15C;
-        public static int v5Size = 0x170;
-        public static int v6Size = 0x2DC;
-        public static int v9Size = 0x2F0;
-        public static int v10Size = 0x3AC;
-
         //Stores palette colors [column, row]
         //Each palette has 7 columns and 6 rows. Overall they mirror the slider backdrop, but with some differences due to it not matching what the game uses
         //All palette data was recreated frrom the .cmx file(s) except for skin. Skin is handled a bit differently than other colors, and so I have recreated it a different way.

--- a/NGS Salon Tool/FaceOverwriteDialog.xaml
+++ b/NGS Salon Tool/FaceOverwriteDialog.xaml
@@ -1,0 +1,44 @@
+﻿<Window x:Class="NGS_Salon_Tool.FaceOverwriteDialog"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:local="clr-namespace:NGS_Salon_Tool"
+        mc:Ignorable="d"
+        Title="FaceOverwriteDialog" Height="250" Width="400">
+    <Grid VerticalAlignment="Center">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="30"/>
+            <RowDefinition Height="30"/>
+            <RowDefinition Height="30"/>
+            <RowDefinition Height="30"/>
+            <RowDefinition Height="30"/>
+        </Grid.RowDefinitions>
+        <Label x:Name="FaceSourceLabel" Grid.Row="0" Content="Select Source Face" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+        <Grid Grid.Row="1" HorizontalAlignment="Center">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="100"/>
+                <ColumnDefinition Width="100"/>
+            </Grid.ColumnDefinitions>
+            <RadioButton x:Name="BaseFaceSourceRadio" GroupName="FaceSource" Grid.Column="0" HorizontalAlignment="Center" VerticalAlignment="Center" IsChecked="True">Base Face</RadioButton>
+            <RadioButton x:Name="AltFaceSourceRadio" GroupName="FaceSource" Grid.Column="1" HorizontalAlignment="Center" VerticalAlignment="Center">Alt Face</RadioButton>
+        </Grid>
+        <Label x:Name="FaceDestLabel" Grid.Row="2" Content="Select Face to Overwrite" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+        <Grid Grid.Row="3" HorizontalAlignment="Center">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="100"/>
+                <ColumnDefinition Width="100"/>
+            </Grid.ColumnDefinitions>
+            <CheckBox x:Name="BaseFaceDestCheckbox" Grid.Column="0" HorizontalAlignment="Center" VerticalAlignment="Center">Base Face</CheckBox>
+            <CheckBox x:Name="AltFaceDestCheckbox" Grid.Column="1" HorizontalAlignment="Center" VerticalAlignment="Center">Alt Face</CheckBox>
+        </Grid>
+        <Grid Grid.Row="4" HorizontalAlignment="Center">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="100"/>
+                <ColumnDefinition Width="100"/>
+            </Grid.ColumnDefinitions>
+            <Button x:Name="ApplyButton" Grid.Column="0" HorizontalAlignment="Center" VerticalAlignment="Center" Content="Apply" IsDefault="true" Click="OnClick_OkayButton"/>
+            <Button x:Name="CancelButton" Grid.Column="1" HorizontalAlignment="Center" VerticalAlignment="Center" Content="Cancel" IsCancel="True"/>
+        </Grid>
+    </Grid>
+</Window>

--- a/NGS Salon Tool/FaceOverwriteDialog.xaml.cs
+++ b/NGS Salon Tool/FaceOverwriteDialog.xaml.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Documents;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using System.Windows.Shapes;
+
+namespace NGS_Salon_Tool
+{
+    /// <summary>
+    /// Interaction logic for FaceOverwriteDialog.xaml
+    /// </summary>
+    public partial class FaceOverwriteDialog : Window
+    {
+        public FaceOverwriteDialog()
+        {
+            InitializeComponent();
+        }
+
+        public bool AltFaceSource
+        {
+            get
+            {
+                return AltFaceSourceRadio.IsChecked.HasValue && AltFaceSourceRadio.IsChecked.Value;
+            }
+        }
+
+        public bool OverwriteBaseFace
+        {
+            get
+            {
+                return BaseFaceDestCheckbox.IsChecked.HasValue && BaseFaceDestCheckbox.IsChecked.Value;
+            }
+        }
+
+        public bool OverwriteAltFace
+        {
+            get
+            {
+                return AltFaceDestCheckbox.IsChecked.HasValue && AltFaceDestCheckbox.IsChecked.Value;
+            }
+        }
+
+        public void EnableAltFaceSource(bool IsEnabled)
+        {
+            AltFaceSourceRadio.IsEnabled = IsEnabled;
+            AltFaceSourceRadio.IsChecked = IsEnabled && AltFaceSourceRadio.IsChecked.HasValue && AltFaceSourceRadio.IsChecked.Value;
+        }
+
+        public void EnableAltFaceDest(bool IsEnabled)
+        {
+            AltFaceDestCheckbox.IsEnabled = IsEnabled;
+            AltFaceDestCheckbox.IsChecked = IsEnabled && AltFaceSourceRadio.IsChecked.HasValue && AltFaceSourceRadio.IsChecked.Value;
+        }
+
+        private void OnClick_OkayButton(object sender, RoutedEventArgs e)
+        {
+            this.DialogResult = true;
+        }
+    }
+}

--- a/NGS Salon Tool/MainWindow.xaml
+++ b/NGS Salon Tool/MainWindow.xaml
@@ -28,6 +28,7 @@
                 </MenuItem>
                 <MenuItem Header="Extra">
                     <MenuItem Header="Ensure data meets Global minimums" Click="SetGlobalMin"/>
+                    <MenuItem Header="Overwrite Face Model" Click="OverwriteFaceModel"/>
                     <MenuItem Header="Decrypt xxp(s) and save" Click="DecryptXXPs"/>
                     <MenuItem Header="Encrypt xxpu(s) and save" Click="EncryptXXPs"/>
                 </MenuItem>

--- a/NGS Salon Tool/MainWindow.xaml.cs
+++ b/NGS Salon Tool/MainWindow.xaml.cs
@@ -332,11 +332,11 @@ namespace NGS_Salon_Tool
         private static void WriteXXP(CharacterHandlerReboot.xxpGeneralReboot xxp, string fileName)
         {
             List<byte> fileData = new List<byte>();
-            int fileSize = CharacterConstants.v10Size;
-            var body = Reloaded.Memory.Struct.GetBytes(xxp.GetXXPV10());
+            int fileSize = xxp.fileSize;
+            var body = xxp.GetBytes();
             body = CharacterHandler.EncryptData(body, fileSize, out int hash);
 
-            fileData.AddRange(BitConverter.GetBytes(0xA));
+            fileData.AddRange(BitConverter.GetBytes(xxp.xxpVersion));
             fileData.AddRange(BitConverter.GetBytes(fileSize));
             fileData.AddRange(BitConverter.GetBytes(hash));
             fileData.AddRange(new byte[] { 0, 0, 0, 0 });
@@ -353,22 +353,22 @@ namespace NGS_Salon_Tool
             switch (version)
             {
                 case 2:
-                    return new CharacterHandlerReboot.xxpGeneralReboot(streamReader.Read<CharacterHandlerReboot.XXPV2>());
+                    return new CharacterHandlerReboot.xxpGeneralRebootV2(streamReader.Read<CharacterHandlerReboot.XXPV2>());
                 case 5:
-                    return new CharacterHandlerReboot.xxpGeneralReboot(streamReader.Read<CharacterHandlerReboot.XXPV5>());
+                    return new CharacterHandlerReboot.xxpGeneralRebootV5(streamReader.Read<CharacterHandlerReboot.XXPV5>());
                 case 6:
-                    return new CharacterHandlerReboot.xxpGeneralReboot(streamReader.Read<CharacterHandlerReboot.XXPV5>());
+                    return new CharacterHandlerReboot.xxpGeneralRebootV6(streamReader.Read<CharacterHandlerReboot.XXPV6>());
                 case 7:
-                    return new CharacterHandlerReboot.xxpGeneralReboot(streamReader.Read<CharacterHandlerReboot.XXPV7>());
+                    return new CharacterHandlerReboot.xxpGeneralRebootV7(streamReader.Read<CharacterHandlerReboot.XXPV7>());
                 case 8:
                 case 9:
-                    return new CharacterHandlerReboot.xxpGeneralReboot(streamReader.Read<CharacterHandlerReboot.XXPV9>());
+                    return new CharacterHandlerReboot.xxpGeneralRebootV9(streamReader.Read<CharacterHandlerReboot.XXPV9>());
                 case 10:
-                    return new CharacterHandlerReboot.xxpGeneralReboot(streamReader.Read<CharacterHandlerReboot.XXPV10>());
+                    return new CharacterHandlerReboot.xxpGeneralRebootV10(streamReader.Read<CharacterHandlerReboot.XXPV10>());
                 case 11:
-                    return new CharacterHandlerReboot.xxpGeneralReboot(streamReader.Read<CharacterHandlerReboot.XXPV11>());
+                    return new CharacterHandlerReboot.xxpGeneralRebootV11(streamReader.Read<CharacterHandlerReboot.XXPV11>());
                 case 12:
-                    return new CharacterHandlerReboot.xxpGeneralReboot(streamReader.Read<CharacterHandlerReboot.XXPV12>());
+                    return new CharacterHandlerReboot.xxpGeneralRebootV12(streamReader.Read<CharacterHandlerReboot.XXPV12>());
                 default:
                     MessageBox.Show("Error: File version unknown. If this is a proper salon file, please report this!");
                     return null;

--- a/NGS Salon Tool/NGS Salon Tool.csproj.user
+++ b/NGS Salon Tool/NGS Salon Tool.csproj.user
@@ -10,9 +10,15 @@
     <Compile Update="ColorWindow\ColorPicker.xaml.cs">
       <SubType>Code</SubType>
     </Compile>
+    <Compile Update="FaceOverwriteDialog.xaml.cs">
+      <SubType>Code</SubType>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <Page Update="ColorWindow\ColorPicker.xaml">
+      <SubType>Designer</SubType>
+    </Page>
+    <Page Update="FaceOverwriteDialog.xaml">
       <SubType>Designer</SubType>
     </Page>
     <Page Update="MainWindow.xaml">


### PR DESCRIPTION
Refactor Character Handler:

Refactor Character Handler instead of 1 handler handles all model versions, there is 1 handler per version.

The reason for this change is checking which version outside of the handler introduces bugs where a switch case for the new version is forgotten (like xxpGeneralReboot::GetBytes).

There is also a bug in WriteXXP. In WriteXXP, it always uses version 10 size and data structure. By moving to 1 handler per model version, we can avoid having to check the size tag and data structure.

Overwrite Face Function:
With the introduction of version 12 of the character model file, pso2 face is stored in AltFaceFIGR. Right now, if the user wants to reuse an old face, they will have to recreate it from scratch or try to load it from an older file and have it overwrite their NGS face.

The overwrite face function will take the face FIGR from another file and overwrites base or NGS face alone.
